### PR TITLE
Fix prerender failure for dev-only nav routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ Thumbs.db
 # Vite
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Claude Code
+.claude/

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -45,6 +45,9 @@ const config = {
 				'/projects/league-of-llm',
 				'/projects/your-music-library',
 				'/blog/sample-blog',
+				'/games',
+				'/ideas',
+				'/temp',
 			]
 		}
 	 },


### PR DESCRIPTION
## Summary

- `/games`, `/ideas`, and `/temp` were moved into an `{#if dev}` dropdown in the header redesign, making them unreachable by SvelteKit's production crawler
- Added the three routes explicitly to `prerender.entries` in `svelte.config.js` so the static adapter still outputs those pages
- Also adds `.claude/` to `.gitignore` (missing from main)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3D57CaWpbnRQ3rSLwq6pM)_