### PR TITLE
Fix layout-test prerender=false breaking static adapter

### DIFF
--- a/src/routes/layout-test/+page.server.ts
+++ b/src/routes/layout-test/+page.server.ts
@@ -6,4 +6,4 @@ export async function load() {
 	return { projects: projects.slice(0, 6), blogs: blogs.slice(0, 3) };
 }
 
-export const prerender = false;
+export const prerender = true;


### PR DESCRIPTION
## Summary

- `src/routes/layout-test/+page.server.ts` had `prerender = false`, which `adapter-static` rejects — it requires all routes to be fully prerenderable
- The page only loads build-time data (`getProjects`, `getBlogs`), so `prerender = true` is correct

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3D57CaWpbnRQ3rSLwq6pM)_