### PR TITLE
Add /layout-test to prerender.entries

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -48,6 +48,7 @@ const config = {
 				'/games',
 				'/ideas',
 				'/temp',
+				'/layout-test',
 			]
 		}
 	 },


### PR DESCRIPTION
## Summary

- `/layout-test` is not linked from the nav so the production crawler can't reach it, causing the prerender step to fail
- Added to `prerender.entries` — same pattern already used for `/games`, `/ideas`, `/temp`
- All unlinked routes are now explicitly listed; no further crawler misses expected

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3D57CaWpbnRQ3rSLwq6pM)_